### PR TITLE
Prefix bug fix

### DIFF
--- a/QtLing/Lexicon.cpp
+++ b/QtLing/Lexicon.cpp
@@ -382,7 +382,7 @@ void CLexicon::step1_from_words_to_protostems()
             if (DifferenceFoundFlag == false){
                 if (!m_suffix_protostems.contains(previous_word)
                         && previous_word_length >= M_MINIMUM_STEM_LENGTH){
-                    m_suffix_protostems[previous_word] = new protostem(previous_word, false);
+                    m_suffix_protostems[previous_word] = new protostem(previous_word, true);
                 }
             }
         }  // end of suffix case.
@@ -395,7 +395,7 @@ void CLexicon::step1_from_words_to_protostems()
                     if (potential_stem.length() == 0) {continue;}
                     DifferenceFoundFlag = true;
                     if (!m_prefix_protostems.contains(potential_stem)) {
-                        m_prefix_protostems[potential_stem] = new protostem(potential_stem);
+                        m_prefix_protostems[potential_stem] = new protostem(potential_stem, false);
                     }
                     break;
                 }// end of having found a difference.
@@ -403,7 +403,7 @@ void CLexicon::step1_from_words_to_protostems()
             if (DifferenceFoundFlag == false){
                 if (!m_prefix_protostems.contains(previous_word)
                         && previous_word_length >= M_MINIMUM_STEM_LENGTH){
-                    m_prefix_protostems[previous_word] = new protostem(previous_word);
+                    m_prefix_protostems[previous_word] = new protostem(previous_word, false);
                 }
             }
         } // end of prefix case.
@@ -597,7 +597,7 @@ void   CLexicon::step3_from_parses_to_stem_to_sig_maps(QString name_of_calling_f
         count++; m_ProgressBar->setValue(count);
         QSet<affix_t>* p_affix_set = these_stem_to_sig_maps[this_stem_t];
 
-        if (p_affix_set->size() == 1) continue; // discard singleton signatures
+        // if (p_affix_set->size() == 1) continue; // discard singleton signatures
 
         this_signature_string = convert_set_to_qstring(p_affix_set);
         m_intermediate_signature_to_stems_map.attach_stem_to_signature(this_stem_t, this_signature_string);

--- a/QtLing/Lexicon.cpp
+++ b/QtLing/Lexicon.cpp
@@ -45,8 +45,8 @@ protostem::~protostem()
 }
 
 CLexicon::CLexicon( CLexicon* lexicon, bool suffix_flag):
-    M_MINIMUM_STEM_LENGTH(3),
-    M_MINIMUM_STEM_COUNT(2),
+    M_MINIMUM_STEM_LENGTH(4),
+    M_MINIMUM_STEM_COUNT(8),
     M_MAXIMUM_AFFIX_LENGTH(10)
 {
     m_Signatures            = new CSignatureCollection(this, true);
@@ -470,7 +470,6 @@ void CLexicon::step1_from_words_to_protostems()
  */
 void CLexicon::step2_from_protostems_to_parses()
 {
-    int MAXIMUM_AFFIX_LENGTH = 10;
     m_ProgressBar->reset();
     m_ProgressBar->setMinimum(0);
     m_ProgressBar->setMaximum(m_Words->get_count());
@@ -495,7 +494,7 @@ void CLexicon::step2_from_protostems_to_parses()
                 stem = word.left(letterno);
                 if(m_suffix_protostems.contains(stem))  {
                     suffix_length = word.length() - letterno;
-                    if (suffix_length > MAXIMUM_AFFIX_LENGTH){
+                    if (suffix_length > M_MAXIMUM_AFFIX_LENGTH){
                         continue;
                     }
                     suffix = word.right(suffix_length);
@@ -510,7 +509,7 @@ void CLexicon::step2_from_protostems_to_parses()
                 stem = word.right(letterno);
                 if (m_prefix_protostems.contains(stem)){
                     prefix_length = word.length() - letterno;
-                    if (prefix_length > MAXIMUM_AFFIX_LENGTH){
+                    if (prefix_length > M_MAXIMUM_AFFIX_LENGTH){
                         continue;
                     }
                     prefix = word.left(prefix_length);
@@ -689,7 +688,7 @@ void CLexicon::step4_create_signatures(QString name_of_calling_function)
         count++;
         m_ProgressBar->setValue(count);
         temp_i++;
-        if (temp_i == 1000){
+        if (temp_i == 100){
             temp_i = 0;
             m_StatusBar->showMessage("4: create signatures: " + this_signature_string);
             qApp->processEvents();

--- a/QtLing/QtLing.pro.user
+++ b/QtLing/QtLing.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.2, 2018-07-19T13:59:06. -->
+<!-- Written by QtCreator 4.6.2, 2018-07-19T15:00:44. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/QtLing/QtLing.pro.user
+++ b/QtLing/QtLing.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.2, 2018-07-18T16:42:12. -->
+<!-- Written by QtCreator 4.6.2, 2018-07-19T13:59:06. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/QtLing/QtLing.pro.user
+++ b/QtLing/QtLing.pro.user
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE QtCreatorProject>
-<!-- Written by QtCreator 4.6.2, 2018-07-19T15:00:44. -->
+<!-- Written by QtCreator 4.6.2, 2018-07-19T16:41:28. -->
 <qtcreator>
  <data>
   <variable>EnvironmentId</variable>

--- a/QtLing/StemCollection.h
+++ b/QtLing/StemCollection.h
@@ -13,7 +13,7 @@ class CLexicon;
 class CStemCollection
 {
 protected:
-
+    //QMap<stem_t, CStem*>
     map_string_to_stem *        m_StringToStemMap;
     int                         m_CorpusCount;
     QString                     m_MemberName;

--- a/QtLing/WordCollection.cpp
+++ b/QtLing/WordCollection.cpp
@@ -108,7 +108,12 @@ bool reverse_string_compare(QString string1, QString string2){
     return false;
 }
 
-
+bool new_reverse_string_compare(QString s1, QString s2)
+{
+    std::reverse(s1.begin(), s1.end());
+    std::reverse(s2.begin(), s2.end());
+    return s1 < s2;
+}
 
 void CWordCollection::sort_word_list()
 {
@@ -121,7 +126,7 @@ void CWordCollection::sort_word_list()
     foreach(QString word, m_WordMap.keys()){
         m_reverse_sort_list.append(word);
     }
-    std::sort(m_reverse_sort_list.begin(),m_reverse_sort_list.end(), reverse_string_compare);
+    std::sort(m_reverse_sort_list.begin(),m_reverse_sort_list.end(), new_reverse_string_compare);
 
 }
 

--- a/QtLing/compound.cpp
+++ b/QtLing/compound.cpp
@@ -1,11 +1,13 @@
 #include "compound.h"
 #include "Lexicon.h"
+#include "StemCollection.h"
 #include "WordCollection.h"
 #include "Word.h"
 #include <QMap>
 #include <QPair>
 #include <QDebug>
 #include <QProgressBar>
+
 
 // -------------- CompoundComponent ---------------- //
 CompoundComponent::CompoundComponent(const QString &word):
@@ -217,6 +219,9 @@ CompoundWord* CompoundWordCollection::add_compound_word
 void CompoundWordCollection::remove_compound_word(CompoundWord* p_word)
 {
     const QString& str_word = p_word->get_word();
+    /*
+    m_lexicon->add_to_word_autobiographies(str_word,
+        QString("[Compound]=I am removed."));*/
     m_map.remove(str_word);
     delete p_word;
 
@@ -245,8 +250,24 @@ void CompoundWordCollection::remove_invalid_components(QProgressBar *p_progressb
             list_to_remove.append(p_component);
         }
     }
+    /*
+    QMap<QString, CStem*>* p_stem_map = m_lexicon->get_suffix_flag()?
+                m_lexicon->get_suffixal_stems()->get_map():
+                m_lexicon->get_prefixal_stems()->get_map();*/
     CompoundComponent* p_component_to_remove;
     foreach (p_component_to_remove, list_to_remove) {
+        /*
+        const QString& str_component = p_component_to_remove->get_word();
+        if (m_lexicon->get_words()->contains(str_component)) {
+            m_lexicon->add_to_word_autobiographies(str_component,
+                QString("[Compound]=I am removed because I am invalid."));
+        }
+        if (p_stem_map->contains(str_component)) {
+            m_lexicon->add_to_stem_autobiographies(str_component,
+                QString("[Compound]=I am removed because I am invalid."));
+        }*/
+
         m_component_collection->remove_component(p_component_to_remove);
+
     }
 }

--- a/QtLing/lexicon_crab2.cpp
+++ b/QtLing/lexicon_crab2.cpp
@@ -31,7 +31,7 @@ void CLexicon::Crab_2()
     step6_ReSignaturizeWithKnownAffixes();
     step7_FindGoodSignaturesInsideParaSignatures();
 
-    find_compounds();
+    //find_compounds();
 
      m_SuffixesFlag ?
         m_Signatures->calculate_stem_entropy():

--- a/QtLing/table_views_lower.cpp
+++ b/QtLing/table_views_lower.cpp
@@ -613,10 +613,11 @@ void LowerTableView::table_protostem(protostem *p_protostem)
     typedef QStandardItem QSI;
     CLexicon* this_lexicon = get_parent_window()->get_lexicon();
     m_my_current_model = new QStandardItemModel();
+    const bool suffixes_flag = this_lexicon->get_suffix_flag();
 
-    QString str_protostem = p_protostem->get_stem();
-    int start_word_index = p_protostem->get_start_word();
-    int end_word_index = p_protostem->get_end_word();
+    const QString& str_protostem = p_protostem->get_stem();
+    const int start_word_index = p_protostem->get_start_word();
+    const int end_word_index = p_protostem->get_end_word();
     QStringList labels;
     labels << "" << str_protostem;
     m_my_current_model->setHorizontalHeaderLabels(labels);
@@ -625,7 +626,9 @@ void LowerTableView::table_protostem(protostem *p_protostem)
         QList<QSI*> item_list;
         QSI* item1 = new QSI();
         item1->setData(wordno, Qt::DisplayRole);
-        QString str_word = this_lexicon->get_words()->get_word_string(wordno);
+        const QString& str_word = suffixes_flag?
+                    this_lexicon->get_words()->get_word_string(wordno):
+                    this_lexicon->get_words()->get_reverse_sort_list()->at(wordno);
         QSI* item2 = new QSI(str_word);
         item_list.append(item1);
         item_list.append(item2);


### PR DESCRIPTION
The reason for the bug that linguistica would crash when running the swahili 301k corpus was related to the constant parameters in the CLexicon class `M_MINIMUM_STEM_LENGTH` and `M_MINIMUM_STEM_COUNT`.  `M_MINIMUM_STEM_LENGTH` is used in step1 and step2 of crab1, and `M_MINIMUM_STEM_COUNT` is used in step4 (it sets the minimum limit for the number of stems corresponding to a proposed signature for it to be considered a valid signature). Linguistca wouldn't crash if the former was set to 4 and the latter was set to 8, and generated similar (though not identical) results to older versions where these constants were defined within each function, rather than constant member variables in the CLexicon object. I also fixed compound discovery so that it can be run with prefixes.