### PR TITLE
[Merge order: 1 or 2] Check for duplicates before adding a sig pointer to a CStem object

### DIFF
--- a/QtLing/Stem.cpp
+++ b/QtLing/Stem.cpp
@@ -13,6 +13,21 @@ CStem::CStem(CStem& stem) {
 
 }
 
+/*!
+ * \brief Adds a signature pointer to the list of pointers stored in a CStem
+ * object, and checks for duplicates before that.
+ * \param p_new_sig
+ *
+ * Added by Hanson in branch add_sig_to_stem_merge, 8.3
+ */
+void CStem::add_signature(CSignature *p_new_sig)
+{
+    foreach (CSignature* p_sig, m_Signatures) {
+        if (p_sig->get_key() == p_new_sig->get_key())
+            return;
+    }
+    m_Signatures.append(p_new_sig);
+}
 
 
 QString CStem::display(){

--- a/QtLing/Stem.h
+++ b/QtLing/Stem.h
@@ -25,7 +25,8 @@ public:
 public:
     //Accessors
     void                add_memo (QString memo) {m_Autobiography.append(memo);}
-    void                add_signature(CSignature* pSig ) {m_Signatures.append(pSig); }
+    void                add_signature(CSignature* pSig ); /* {m_Signatures.append(pSig); } */
+    // added a function definitino for this function, add_sig_to_stem_merge, HL 8.3
     void                add_suffix_to_parasignature(CSuffix* pSuffix) { m_parasignature.append(pSuffix);}
     QString             display();
     QString             get_key()               const{return m_key;}


### PR DESCRIPTION
You can merge this branch either before or after merging the one for compound discovery.